### PR TITLE
Add shared iOS automatic image attachment settings

### DIFF
--- a/penny-client/PennyClient.xcodeproj/project.pbxproj
+++ b/penny-client/PennyClient.xcodeproj/project.pbxproj
@@ -26,8 +26,8 @@
 
 /* Begin PBXFileReference section */
 		000000000000000000000120 /* PennyDev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PennyDev.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D18FD9B42FF98AC900225D47 /* PennyClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PennyClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000002 /* PennyServicesStandaloneTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PennyServicesStandaloneTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D18FD9B42FF98AC900225D47 /* PennyClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PennyClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D1F83D7E2FF98F1D0010DBDD /* PennyClient.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PennyClient.xctestplan; sourceTree = "<group>"; };
 		D1F83D832FF9A0000010DBDD /* PennyTestflight.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PennyTestflight.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -38,14 +38,14 @@
 			path = PennyClient;
 			sourceTree = "<group>";
 		};
+		A10000000000000000000003 /* PennyServices/Tests/PennyServicesTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PennyServices/Tests/PennyServicesTests;
+			sourceTree = "<group>";
+		};
 		D18FD9B52FF98AC900225D47 /* PennyClientTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = PennyClientTests;
-			sourceTree = "<group>";
-		};
-		A10000000000000000000003 /* PennyServicesTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = PennyServices/Tests/PennyServicesTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -57,15 +57,15 @@
 				A00000000000000000000001 /* PennyServices in Frameworks */,
 			);
 		};
-		D18FD9B12FF98AC900225D47 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			files = (
-			);
-		};
 		A10000000000000000000004 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			files = (
 				A10000000000000000000001 /* PennyServices in Frameworks */,
+			);
+		};
+		D18FD9B12FF98AC900225D47 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
 			);
 		};
 		D1F83D842FF9A0000010DBDD /* Frameworks */ = {
@@ -83,7 +83,7 @@
 				D1F83D7E2FF98F1D0010DBDD /* PennyClient.xctestplan */,
 				000000000000000000000010 /* PennyClient */,
 				D18FD9B52FF98AC900225D47 /* PennyClientTests */,
-				A10000000000000000000003 /* PennyServicesTests */,
+				A10000000000000000000003 /* PennyServices/Tests/PennyServicesTests */,
 				000000000000000000000020 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -126,6 +126,27 @@
 			productReference = 000000000000000000000120 /* PennyDev.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A10000000000000000000005 /* PennyServicesStandaloneTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000010 /* Build configuration list for PBXNativeTarget "PennyServicesStandaloneTests" */;
+			buildPhases = (
+				A10000000000000000000006 /* Sources */,
+				A10000000000000000000004 /* Frameworks */,
+				A10000000000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			fileSystemSynchronizedGroups = (
+				A10000000000000000000003 /* PennyServices/Tests/PennyServicesTests */,
+			);
+			name = PennyServicesStandaloneTests;
+			packageProductDependencies = (
+				A00000000000000000000002 /* PennyServices */,
+			);
+			productName = PennyServicesStandaloneTests;
+			productReference = A10000000000000000000002 /* PennyServicesStandaloneTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D18FD9B32FF98AC900225D47 /* PennyClientTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D18FD9BA2FF98AC900225D47 /* Build configuration list for PBXNativeTarget "PennyClientTests" */;
@@ -144,8 +165,6 @@
 				D18FD9B52FF98AC900225D47 /* PennyClientTests */,
 			);
 			name = PennyClientTests;
-			packageProductDependencies = (
-			);
 			productName = PennyClientTests;
 			productReference = D18FD9B42FF98AC900225D47 /* PennyClientTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -174,29 +193,6 @@
 			productName = PennyTestflight;
 			productReference = D1F83D832FF9A0000010DBDD /* PennyTestflight.app */;
 			productType = "com.apple.product-type.application";
-		};
-		A10000000000000000000005 /* PennyServicesStandaloneTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A10000000000000000000010 /* Build configuration list for PBXNativeTarget "PennyServicesStandaloneTests" */;
-			buildPhases = (
-				A10000000000000000000006 /* Sources */,
-				A10000000000000000000004 /* Frameworks */,
-				A10000000000000000000007 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				A10000000000000000000003 /* PennyServicesTests */,
-			);
-			name = PennyServicesStandaloneTests;
-			packageProductDependencies = (
-				A00000000000000000000002 /* PennyServices */,
-			);
-			productName = PennyServicesStandaloneTests;
-			productReference = A10000000000000000000002 /* PennyServicesStandaloneTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -239,7 +235,7 @@
 			productRefGroup = 000000000000000000000020 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
-				targets = (
+			targets = (
 				000000000000000100000000 /* PennyDev */,
 				D1F83D852FF9A0000010DBDD /* PennyTestflight */,
 				D18FD9B32FF98AC900225D47 /* PennyClientTests */,
@@ -255,6 +251,11 @@
 				D1F83D7F2FF98F1D0010DBDD /* PennyClient.xctestplan in Resources */,
 			);
 		};
+		A10000000000000000000007 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+			);
+		};
 		D18FD9B22FF98AC900225D47 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
@@ -264,11 +265,6 @@
 			isa = PBXResourcesBuildPhase;
 			files = (
 				D1F83D822FF9A0000010DBDD /* PennyClient.xctestplan in Resources */,
-			);
-		};
-		A10000000000000000000007 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			files = (
 			);
 		};
 /* End PBXResourcesBuildPhase section */
@@ -302,17 +298,17 @@
 			files = (
 			);
 		};
+		A10000000000000000000006 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+			);
+		};
 		D18FD9B02FF98AC900225D47 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
 			);
 		};
 		D1F83D862FF9A0000010DBDD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			files = (
-			);
-		};
-		A10000000000000000000006 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
 			);
@@ -590,6 +586,53 @@
 			};
 			name = Release;
 		};
+		A10000000000000000000008 /* Debug configuration for PBXNativeTarget "PennyServicesStandaloneTests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = P87URHZFZ4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.leveltenpaladin.PennyServicesStandaloneTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A10000000000000000000009 /* Release configuration for PBXNativeTarget "PennyServicesStandaloneTests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = P87URHZFZ4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.leveltenpaladin.PennyServicesStandaloneTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		D18FD9BB2FF98AC900225D47 /* Debug configuration for PBXNativeTarget "PennyClientTests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -759,53 +802,6 @@
 			};
 			name = Release;
 		};
-		A10000000000000000000008 /* Debug configuration for PBXNativeTarget "PennyServicesStandaloneTests" */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = P87URHZFZ4;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.leveltenpaladin.PennyServicesStandaloneTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				STRING_CATALOG_GENERATE_SYMBOLS = NO;
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		A10000000000000000000009 /* Release configuration for PBXNativeTarget "PennyServicesStandaloneTests" */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = P87URHZFZ4;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.leveltenpaladin.PennyServicesStandaloneTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				STRING_CATALOG_GENERATE_SYMBOLS = NO;
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -825,6 +821,14 @@
 			);
 			defaultConfigurationName = Release;
 		};
+		A10000000000000000000010 /* Build configuration list for PBXNativeTarget "PennyServicesStandaloneTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A10000000000000000000008 /* Debug configuration for PBXNativeTarget "PennyServicesStandaloneTests" */,
+				A10000000000000000000009 /* Release configuration for PBXNativeTarget "PennyServicesStandaloneTests" */,
+			);
+			defaultConfigurationName = Release;
+		};
 		D18FD9BA2FF98AC900225D47 /* Build configuration list for PBXNativeTarget "PennyClientTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -838,14 +842,6 @@
 			buildConfigurations = (
 				D1F83D892FF9A0000010DBDD /* Debug configuration for PBXNativeTarget "PennyTestflight" */,
 				D1F83D8A2FF9A0000010DBDD /* Release configuration for PBXNativeTarget "PennyTestflight" */,
-			);
-			defaultConfigurationName = Release;
-		};
-		A10000000000000000000010 /* Build configuration list for PBXNativeTarget "PennyServicesStandaloneTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A10000000000000000000008 /* Debug configuration for PBXNativeTarget "PennyServicesStandaloneTests" */,
-				A10000000000000000000009 /* Release configuration for PBXNativeTarget "PennyServicesStandaloneTests" */,
 			);
 			defaultConfigurationName = Release;
 		};

--- a/penny-client/PennyClient/Views/AdminFeatureViewModels.swift
+++ b/penny-client/PennyClient/Views/AdminFeatureViewModels.swift
@@ -232,7 +232,7 @@ final class SettingsViewModel {
     }
 
     var runtimeConfigParams: [RuntimeConfigParam] {
-        client.runtimeConfigParams
+        client.runtimeConfigParams.filter { ImageAttachmentSetting(rawValue: $0.key) == nil }
     }
 
     var domainPermissions: [DomainPermissionEntry] {

--- a/penny-client/PennyClient/Views/ImageAttachmentSettingsSection.swift
+++ b/penny-client/PennyClient/Views/ImageAttachmentSettingsSection.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import PennyServices
+
+struct ImageAttachmentSettingsSection: View {
+    let viewModel: SettingsViewModel
+
+    var body: some View {
+        Section {
+            ForEach(ImageAttachmentSetting.allCases) { setting in
+                Toggle(isOn: Binding(
+                    get: { viewModel.imageSettingValue(setting) },
+                    set: { viewModel.setImageSetting(setting, enabled: $0) }
+                )) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(setting.title)
+                        if setting == .related {
+                            Text("Includes previously generated images.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .disabled(!viewModel.canEditImageSetting(setting))
+            }
+            if let status = viewModel.imageSettingsStatus {
+                Text(status)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let error = viewModel.client.imageAttachmentSettings.error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                Button("Refresh Settings") { viewModel.refresh() }
+                    .disabled(!viewModel.client.canSend)
+            }
+        } header: {
+            HStack(spacing: 8) {
+                Text("Image Attachments")
+                if viewModel.client.imageAttachmentSettings.pendingSetting != nil {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .accessibilityLabel("Saving image setting")
+                }
+            }
+        }
+    }
+}
+
+extension SettingsViewModel {
+    var imageSettingsStatus: String? {
+        if !client.canSend { return "Connect to edit shared image settings." }
+        if !client.hasLoadedRuntimeConfig { return "Loading image settings…" }
+        if !client.supportsImageAttachmentSettings { return "Update the server to enable image settings." }
+        return nil
+    }
+
+    func imageSettingValue(_ setting: ImageAttachmentSetting) -> Bool {
+        if client.imageAttachmentSettings.pendingSetting == setting,
+           let pendingValue = client.imageAttachmentSettings.pendingValue {
+            return pendingValue
+        }
+        return client.runtimeConfigParams.first { $0.key == setting.rawValue }?.value != "0"
+    }
+
+    func canEditImageSetting(_ setting: ImageAttachmentSetting) -> Bool {
+        client.canSend && client.supportsImageAttachmentSettings
+            && client.imageAttachmentSettings.pendingSetting == nil
+            && (setting == .automatic || imageSettingValue(.automatic))
+    }
+
+    func setImageSetting(_ setting: ImageAttachmentSetting, enabled: Bool) {
+        guard canEditImageSetting(setting), enabled != imageSettingValue(setting) else { return }
+        client.updateImageAttachmentSetting(setting, enabled: enabled)
+    }
+}
+
+private extension ImageAttachmentSetting {
+    var title: String {
+        switch self {
+        case .automatic: "Automatic images"
+        case .citedPage: "Images from cited pages"
+        case .sameSite: "Images from the same site"
+        case .related: "Related images"
+        }
+    }
+}

--- a/penny-client/PennyClient/Views/SettingsView.swift
+++ b/penny-client/PennyClient/Views/SettingsView.swift
@@ -51,6 +51,8 @@ struct SettingsView: View {
                     }
                 }
 
+                ImageAttachmentSettingsSection(viewModel: viewModel)
+
                 Section("History") {
                     ForEach(HistoryChannel.allCases) { channel in
                         Toggle(channel.title, isOn: Binding(

--- a/penny-client/PennyClientTests/PennyAdminViewModelTests.swift
+++ b/penny-client/PennyClientTests/PennyAdminViewModelTests.swift
@@ -140,7 +140,7 @@ struct PennyAdminViewModelTests {
         {"type":"registered","device_id":"device","is_default":true,"pending_count":0}
         """)
         #expect(viewModel.canSendTestNotification)
-        _ = await sentPayloads(transport, count: 1)
+        _ = await sentPayloads(transport, count: 2)
         transport.clearSentPayloads()
 
         viewModel.refresh()
@@ -369,4 +369,60 @@ private func promptLogsResponseJSON(hasMore: Bool) -> String {
       ]
     }
     """
+}
+
+@Suite(.serialized)
+@MainActor
+struct ImageAttachmentSettingsViewModelTests {
+    @Test func imageTogglesFollowAvailabilityConfirmationAndAutomaticSwitch() async throws {
+        let prefs = configuredPrefs()
+        let (client, transport) = makeAdminClient(prefs: prefs)
+        let viewModel = SettingsViewModel(client: client, prefs: prefs)
+        #expect(!viewModel.canEditImageSetting(.automatic))
+        await connectAndClearStartupFrames(client, transport)
+        transport.emit("""
+        {"type":"registered","device_id":"device","is_default":true,"pending_count":0}
+        """)
+        _ = await sentPayloads(transport, count: 2)
+        #expect(viewModel.imageSettingsStatus == "Loading image settings…")
+        transport.emit("{\"type\":\"config_response\",\"params\":[]}")
+        #expect(!viewModel.canEditImageSetting(.automatic))
+        #expect(viewModel.imageSettingsStatus == "Update the server to enable image settings.")
+        transport.emit(imageConfigJSON())
+        #expect(viewModel.imageSettingsStatus == nil)
+        #expect(viewModel.runtimeConfigParams.isEmpty)
+        #expect(ImageAttachmentSetting.allCases.allSatisfy { viewModel.canEditImageSetting($0) })
+        transport.clearSentPayloads()
+        viewModel.setImageSetting(.automatic, enabled: false)
+        #expect(!viewModel.imageSettingValue(.automatic))
+        #expect(!viewModel.canEditImageSetting(.related))
+        #expect(!viewModel.canEditImageSetting(.automatic))
+        let payloads = await sentPayloads(transport, count: 1)
+        guard case .string(let identifier)? = payloads.first?["request_id"] else {
+            Issue.record("Missing image update correlation")
+            return
+        }
+        transport.emit(imageConfigJSON(requestID: identifier, automatic: "0"))
+        #expect(viewModel.canEditImageSetting(.automatic))
+        #expect(!viewModel.canEditImageSetting(.citedPage))
+        #expect(viewModel.imageSettingValue(.citedPage)) // retained while master is off
+        viewModel.setImageSetting(.related, enabled: false)
+        #expect(client.imageAttachmentSettings.pendingSetting == nil)
+        viewModel.setImageSetting(.automatic, enabled: true)
+        #expect(viewModel.imageSettingValue(.automatic))
+        client.disconnect()
+        #expect(!viewModel.canEditImageSetting(.automatic))
+        #expect(client.imageAttachmentSettings.error != nil)
+    }
+}
+
+private func imageConfigJSON(requestID: String? = nil, automatic: String = "1") -> String {
+    let params = ImageAttachmentSetting.allCases.map { setting in
+        """
+        {"key":"\(setting.rawValue)","value":"\(setting == .automatic ? automatic : "1")",
+        "default":"1","description":"Image setting","type":"int","group":"iOS Attachments"}
+        """
+    }.joined(separator: ",")
+    let correlation = requestID.map { ",\"request_id\":\"\($0)\"" } ?? ""
+    return "{\"type\":\"config_response\",\"params\":[\(params)]\(correlation)}"
 }

--- a/penny-client/PennyServices/Sources/PennyServices/ImageAttachmentSettings.swift
+++ b/penny-client/PennyServices/Sources/PennyServices/ImageAttachmentSettings.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Observation
+
+public enum ImageAttachmentSetting: String, CaseIterable, Identifiable, Sendable {
+    case automatic = "IOS_AUTOMATIC_IMAGES"
+    case citedPage = "IOS_CITED_PAGE_IMAGES"
+    case sameSite = "IOS_SAME_SITE_IMAGES"
+    case related = "IOS_RELATED_IMAGES"
+
+    public var id: String { rawValue }
+}
+
+/// Tracks confirmation separately from the server's authoritative config values.
+@MainActor
+@Observable
+public final class ImageAttachmentSettings {
+    public private(set) var pendingSetting: ImageAttachmentSetting?
+    public private(set) var pendingValue: Bool?
+    public private(set) var error: String?
+    private(set) var requestID: String?
+    @ObservationIgnored private var timeoutTask: Task<Void, Never>?
+
+    func begin(_ setting: ImageAttachmentSetting, enabled: Bool) -> String {
+        let identifier = UUID().uuidString
+        requestID = identifier
+        pendingSetting = setting
+        pendingValue = enabled
+        error = nil
+        timeoutTask?.cancel()
+        timeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(10))
+                self?.fail(requestID: identifier, message: "Could not confirm the change. Refresh settings and try again.")
+            } catch { return }
+        }
+        return identifier
+    }
+
+    func receive(_ payload: ConfigResponsePayload) -> Bool {
+        guard let identifier = payload.requestID else {
+            if pendingSetting == nil { error = nil }
+            return true
+        }
+        guard identifier == requestID, let setting = pendingSetting else { return false }
+        let value = payload.params.first { $0.key == setting.rawValue }?.value
+        let expectedValue = pendingValue == true ? "1" : "0"
+        let failure = payload.error ?? (value == expectedValue ? nil : "The change was not saved. Try again.")
+        finish(error: failure)
+        return true
+    }
+
+    func fail(requestID identifier: String?, message: String) {
+        guard let identifier, identifier == requestID else { return }
+        finish(error: message)
+    }
+
+    func disconnect() {
+        guard requestID != nil else { return }
+        finish(error: "Connection lost before the change was confirmed. Reconnect to refresh settings.")
+    }
+
+    private func finish(error: String?) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        requestID = nil
+        pendingSetting = nil
+        pendingValue = nil
+        self.error = error
+    }
+}

--- a/penny-client/PennyServices/Sources/PennyServices/PennyService.swift
+++ b/penny-client/PennyServices/Sources/PennyServices/PennyService.swift
@@ -64,6 +64,8 @@ public final class PennyService {
     }
     public var lastError: String?
     public var runtimeConfigParams: [RuntimeConfigParam] = []
+    public private(set) var hasLoadedRuntimeConfig = false
+    public let imageAttachmentSettings = ImageAttachmentSettings()
     public var promptLogRuns: [PromptLogRun] = []
     public var promptLogsHasMore = false
     public var memories: [MemoryRecord] = []
@@ -120,6 +122,12 @@ public final class PennyService {
 
     public var canSend: Bool {
         isConnected && isRegistered
+    }
+
+    public var supportsImageAttachmentSettings: Bool {
+        hasLoadedRuntimeConfig && ImageAttachmentSetting.allCases.allSatisfy { setting in
+            runtimeConfigParams.contains { $0.key == setting.rawValue && ["0", "1"].contains($0.value) }
+        }
     }
 
     public var apnsHost: String {
@@ -180,6 +188,9 @@ extension PennyService {
     }
 
     private func disconnect(clearLiveBindings: Bool) {
+        imageAttachmentSettings.disconnect()
+        hasLoadedRuntimeConfig = false
+        runtimeConfigParams = []
         stopBackgroundTasks()
         historyResponseContinuation?.finish()
         historyResponseContinuation = nil
@@ -340,6 +351,13 @@ extension PennyService {
 
     public func updateConfig(key: String, value: String) {
         send(.configUpdate(key: key, value: value))
+    }
+
+    public func updateImageAttachmentSetting(_ setting: ImageAttachmentSetting, enabled: Bool) {
+        guard canSend, supportsImageAttachmentSettings,
+              imageAttachmentSettings.pendingSetting == nil else { return }
+        let requestID = imageAttachmentSettings.begin(setting, enabled: enabled)
+        send(.configUpdate(key: setting.rawValue, value: enabled ? "1" : "0", requestID: requestID))
     }
 
     public func requestPromptLogs(
@@ -554,6 +572,7 @@ extension PennyService {
             isConnected = true
             isRegistered = true
             pendingCount = payload.pendingCount
+            requestConfig()
             send(.pullMessages(limit: pendingMessagePullLimit))
             resumeHistorySyncIfNeeded()
         case .outboxChanged(let payload):
@@ -602,7 +621,10 @@ extension PennyService {
         case .agentProgress(let payload):
             applyAgentProgress(payload)
         case .configResponse(let payload):
-            runtimeConfigParams = payload.params
+            if imageAttachmentSettings.receive(payload) {
+                runtimeConfigParams = payload.params
+                hasLoadedRuntimeConfig = true
+            }
         case .promptLogsResponse(let payload):
             if payload.runs.isEmpty || promptLogRuns.isEmpty {
                 promptLogRuns = payload.runs
@@ -869,6 +891,12 @@ extension PennyService {
             } catch {
                 await MainActor.run {
                     self.lastError = error.localizedDescription
+                    if case .configUpdate(_, _, let requestID) = outgoingMessage {
+                        self.imageAttachmentSettings.fail(
+                            requestID: requestID,
+                            message: "Could not send the change. Check the connection and try again."
+                        )
+                    }
                 }
             }
         }

--- a/penny-client/PennyServices/Sources/PennyServices/PennyServiceAdminModels.swift
+++ b/penny-client/PennyServices/Sources/PennyServices/PennyServiceAdminModels.swift
@@ -21,6 +21,14 @@ public struct RuntimeConfigParam: Decodable, Identifiable {
 
 struct ConfigResponsePayload: Decodable {
     let params: [RuntimeConfigParam]
+    let requestID: String?
+    let error: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case params
+        case requestID = "request_id"
+        case error
+    }
 }
 
 public enum RunOutcome: String, Codable {

--- a/penny-client/PennyServices/Sources/PennyServices/PennyServiceWireProtocol.swift
+++ b/penny-client/PennyServices/Sources/PennyServices/PennyServiceWireProtocol.swift
@@ -13,7 +13,7 @@ enum ClientMessage: Encodable {
     case embeddingRequest(requestID: String, text: String)
     case heartbeat
     case configRequest
-    case configUpdate(key: String, value: String)
+    case configUpdate(key: String, value: String, requestID: String? = nil)
     case promptLogsRequest(agentName: String?, offset: Int?, query: String?, flaggedOnly: Bool?)
     case memoriesRequest(query: String?)
     case memoryDetailRequest(name: String, query: String?)
@@ -89,10 +89,11 @@ enum ClientMessage: Encodable {
             try container.encode("heartbeat", forKey: .type)
         case .configRequest:
             try container.encode("config_request", forKey: .type)
-        case .configUpdate(let key, let value):
+        case .configUpdate(let key, let value, let requestID):
             try container.encode("config_update", forKey: .type)
             try container.encode(key, forKey: .key)
             try container.encode(value, forKey: .value)
+            try container.encodeIfPresent(requestID, forKey: .requestID)
         case .promptLogsRequest(let agentName, let offset, let query, let flaggedOnly):
             try container.encode("prompt_logs_request", forKey: .type)
             try container.encodeIfPresent(agentName, forKey: .agentName)
@@ -209,8 +210,10 @@ enum ClientMessage: Encodable {
             return "embedding_response:\(requestID)"
         case .testNotification, .heartbeat:
             return nil
-        case .configRequest, .configUpdate:
+        case .configRequest:
             return "config_response"
+        case .configUpdate(_, _, let requestID):
+            return requestID.map { "config_response:\($0)" } ?? "config_response"
         case .promptLogsRequest:
             return "prompt_logs_response"
         case .memoriesRequest:
@@ -519,8 +522,8 @@ enum ServerEnvelope: Decodable {
             return nil
         case .agentProgress:
             return nil
-        case .configResponse:
-            return "config_response"
+        case .configResponse(let payload):
+            return payload.requestID.map { "config_response:\($0)" } ?? "config_response"
         case .promptLogsResponse:
             return "prompt_logs_response"
         case .promptLogUpdate:

--- a/penny-client/PennyServices/Tests/PennyServicesTests/ImageAttachmentSettingsTests.swift
+++ b/penny-client/PennyServices/Tests/PennyServicesTests/ImageAttachmentSettingsTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+@testable import PennyServices
+
+@Suite(.serialized)
+@MainActor
+struct ImageAttachmentSettingsTests {
+    @Test func confirmsOnlyMatchingUpdatesAndRefreshesOnReconnect() async throws {
+        let (service, transport) = await subject()
+        #expect(transport.payloads.contains { $0["type"] == .string("config_request") })
+        #expect(!service.supportsImageAttachmentSettings)
+        transport.emit(configJSON())
+        #expect(service.supportsImageAttachmentSettings)
+        transport.payloads = []
+        service.updateImageAttachmentSetting(.automatic, enabled: false)
+        let identifier = try #require(service.imageAttachmentSettings.requestID)
+        await drainTasks()
+        #expect(transport.payloads == [[
+            "type": .string("config_update"), "key": .string("IOS_AUTOMATIC_IMAGES"),
+            "value": .string("0"), "request_id": .string(identifier)
+        ]])
+        transport.emit(configJSON()) // an unrelated refresh is not an acknowledgement
+        #expect(service.imageAttachmentSettings.pendingSetting == .automatic)
+        service.updateImageAttachmentSetting(.related, enabled: false)
+        #expect(service.imageAttachmentSettings.requestID == identifier)
+        transport.emit(configJSON(requestID: identifier, automatic: "0"))
+        #expect(service.imageAttachmentSettings.pendingSetting == nil)
+        #expect(service.imageAttachmentSettings.error == nil)
+        #expect(service.runtimeConfigParams.first?.value == "0")
+        service.disconnect()
+        #expect(!service.supportsImageAttachmentSettings)
+        #expect(service.runtimeConfigParams.isEmpty)
+        await service.connect()
+        transport.emit(registeredJSON)
+        await drainTasks()
+        #expect(!service.hasLoadedRuntimeConfig)
+        transport.emit(configJSON(automatic: "0"))
+        #expect(service.runtimeConfigParams.first?.value == "0")
+        service.disconnect()
+    }
+
+    @Test func rejectionTimeoutAndLateResponsesPreserveConfirmedValues() async throws {
+        let (service, transport) = await subject()
+        transport.emit(configJSON())
+        service.updateImageAttachmentSetting(.automatic, enabled: false)
+        let rejectedID = try #require(service.imageAttachmentSettings.requestID)
+        transport.emit(configJSON(requestID: rejectedID, error: "Setting rejected"))
+        #expect(service.imageAttachmentSettings.error == "Setting rejected")
+        #expect(service.runtimeConfigParams.first?.value == "1")
+        service.updateImageAttachmentSetting(.automatic, enabled: false)
+        let expiredID = try #require(service.imageAttachmentSettings.requestID)
+        service.imageAttachmentSettings.fail(requestID: expiredID, message: "Timed out")
+        #expect(service.imageAttachmentSettings.error == "Timed out")
+        service.updateImageAttachmentSetting(.automatic, enabled: false)
+        let retryID = try #require(service.imageAttachmentSettings.requestID)
+        transport.emit(configJSON(requestID: expiredID, automatic: "0"))
+        #expect(service.imageAttachmentSettings.requestID == retryID)
+        #expect(service.runtimeConfigParams.first?.value == "1")
+        transport.emit(configJSON(requestID: retryID)) // correlated response, but unchanged value
+        #expect(service.imageAttachmentSettings.error != nil)
+        transport.emit(configJSON())
+        #expect(service.imageAttachmentSettings.error == nil)
+        service.disconnect()
+    }
+
+    @Test func sendFailureAndDisconnectEndPendingChanges() async throws {
+        let (service, transport) = await subject()
+        transport.emit(configJSON())
+        transport.rejectSends = true
+        service.updateImageAttachmentSetting(.related, enabled: false)
+        await drainTasks()
+        #expect(service.imageAttachmentSettings.pendingSetting == nil)
+        #expect(service.imageAttachmentSettings.error != nil)
+        transport.rejectSends = false
+        service.updateImageAttachmentSetting(.automatic, enabled: false)
+        service.disconnect()
+        #expect(service.imageAttachmentSettings.pendingSetting == nil)
+        #expect(service.imageAttachmentSettings.error != nil)
+    }
+
+    @Test func oldServersAndDisconnectedClientsCannotUpdateImages() async {
+        let (service, transport) = await subject()
+        transport.emit("{\"type\":\"config_response\",\"params\":[]}")
+        #expect(service.hasLoadedRuntimeConfig)
+        #expect(!service.supportsImageAttachmentSettings)
+        service.updateImageAttachmentSetting(.automatic, enabled: false)
+        #expect(service.imageAttachmentSettings.pendingSetting == nil)
+        transport.emit(configJSON())
+        service.disconnect()
+        service.updateImageAttachmentSetting(.automatic, enabled: false)
+        #expect(service.imageAttachmentSettings.pendingSetting == nil)
+    }
+}
+
+private let registeredJSON = """
+{"type":"registered","device_id":"device","is_default":true,"pending_count":0}
+"""
+
+private func configJSON(requestID: String? = nil, automatic: String = "1", error: String? = nil) -> String {
+    let params = ImageAttachmentSetting.allCases.map { setting in
+        """
+        {"key":"\(setting.rawValue)","value":"\(setting == .automatic ? automatic : "1")",
+        "default":"1","description":"Image setting","type":"int","group":"iOS Attachments"}
+        """
+    }.joined(separator: ",")
+    let correlation = requestID.map { ",\"request_id\":\"\($0)\"" } ?? ""
+    let failure = error.map { ",\"error\":\"\($0)\"" } ?? ""
+    return "{\"type\":\"config_response\",\"params\":[\(params)]\(correlation)\(failure)}"
+}
+
+@MainActor
+private func subject() async -> (PennyService, ImageSettingsTransport) {
+    let transport = ImageSettingsTransport()
+    let service = PennyService(databaseService: configuredDatabase(), prefs: configuredPrefs(), webSocketClient: transport)
+    await service.connect()
+    transport.emit(registeredJSON)
+    await drainTasks()
+    return (service, transport)
+}
+
+@MainActor
+private func drainTasks() async {
+    for _ in 0..<30 { await Task.yield() }
+}
+
+@MainActor
+private final class ImageSettingsTransport: WebSocketTransport {
+    var isConnected = false
+    var rejectSends = false
+    var payloads: [[String: JSONValue]] = []
+    private var receiver: ReceiveHandler?
+
+    func connect(request: URLRequest, onReceive: @escaping ReceiveHandler, onFailure: @escaping FailureHandler) {
+        receiver = onReceive
+        isConnected = true
+    }
+
+    func disconnect() {
+        isConnected = false
+        receiver = nil
+    }
+
+    func send(_ data: Data) async throws {
+        if rejectSends { throw URLError(.networkConnectionLost) }
+        payloads.append(try JSONDecoder().decode([String: JSONValue].self, from: data))
+    }
+
+    func emit(_ json: String) { receiver?(Data(json.utf8)) }
+}

--- a/penny-client/PennyServices/Tests/PennyServicesTests/PennyWebSocketClientTests.swift
+++ b/penny-client/PennyServices/Tests/PennyServicesTests/PennyWebSocketClientTests.swift
@@ -97,7 +97,7 @@ struct PennyWebSocketClientTests {
         transport.emit("""
         {"type":"registered","device_id":"device","is_default":true,"pending_count":0}
         """)
-        _ = await sentPayloads(transport, count: 1)
+        _ = await sentPayloads(transport, count: 2)
         transport.clearSentPayloads()
         client.sendTestNotification()
         let payloads = await sentPayloads(transport, count: 1)
@@ -120,7 +120,7 @@ struct PennyWebSocketClientTests {
         """)
 
         let requestTask = Task { try await client.requestEmbedding("coffee") }
-        let payloads = await sentPayloads(transport, count: 3)
+        let payloads = await sentPayloads(transport, count: 5)
         guard case .string(let requestID)? = payloads.last?["request_id"] else {
             Issue.record("Embedding request did not include a request_id")
             return

--- a/penny-client/README.md
+++ b/penny-client/README.md
@@ -7,3 +7,11 @@ build verification on a freshly booted simulator). For service-only changes,
 `make client-services-check` runs `PennyServicesStandaloneTests` without
 building or launching an app target. CI runs the complete gate on pull requests
 touching `penny-client/`.
+
+Settings → Image Attachments controls automatic images for the entire iOS channel:
+cited-page images, same-site images, and broader related images. All switches start
+enabled. Changes save immediately to the server with confirmation and error state;
+the connection settings' Save button is separate. Explicit attachments and images
+generated for the current request always remain deliverable. The controls affect
+new replies; existing messages and the History attachment option are unchanged.
+An older server that does not expose all four switches shows disabled controls.

--- a/penny/penny/channels/README.md
+++ b/penny/penny/channels/README.md
@@ -152,6 +152,30 @@ delivery and background APNs notifications:
   returned `next_cursor` and resend it after reconnecting to resume.
 - `ack_messages`: `ids`
 - `heartbeat`
+- `config_request`: fetch shared runtime settings
+- `config_update`: `key`, `value`, optional `request_id`. The iOS endpoint echoes
+  `request_id` in its `config_response`; validation failures also include `error`.
+  The response includes current `params`, so clients confirm the saved value.
+
+### Image attachment settings
+
+The **iOS Attachments** runtime group contains four shared switches, each accepting
+`0` or `1` and defaulting to `1`:
+
+- `IOS_AUTOMATIC_IMAGES`: master switch for automatic attachments.
+- `IOS_CITED_PAGE_IMAGES`: images captured from an exact cited page.
+- `IOS_SAME_SITE_IMAGES`: images from other pages on a cited site.
+- `IOS_RELATED_IMAGES`: broader matches, including previously generated images.
+
+Settings apply to new conversational and collector replies across all iOS devices,
+before their outbox entries are created. Explicit attachments and images generated
+in the current reply bypass these switches. Each stored candidate belongs to its
+strongest matching category; a disabled category cannot reappear through fallback.
+Matching order and ranking remain unchanged among eligible images.
+
+Already queued messages, history downloads, and other channels are unaffected.
+`include_attachments` remains an independent history-download option. Attachment
+records retain their existing inline data-URL format.
 
 ### Server messages
 

--- a/penny/penny/channels/base.py
+++ b/penny/penny/channels/base.py
@@ -17,6 +17,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from penny.config import Config
 from penny.constants import PennyConstants, PermissionResolution
 from penny.conversation_machine import ConversationMachine, RoundFraming, TurnEntry
+from penny.database.media_store import ImageSelectionPolicy
 from penny.database.models import Media, MessageLog
 from penny.llm import LlmClient
 from penny.llm.embeddings import serialize_embedding
@@ -474,10 +475,14 @@ class MessageChannel(ABC):
         if generated:
             return generated
         urls = _MESSAGE_URL_RE.findall(text)
-        media = self._db.media.select_image(urls, embedding)
+        media = self._db.media.select_image(urls, embedding, policy=self._image_selection_policy())
         if media is None:
             return None
         return [self._encode_media_row(media)]
+
+    def _image_selection_policy(self) -> ImageSelectionPolicy:
+        """Channels can restrict automatic images without changing explicit delivery."""
+        return ImageSelectionPolicy()
 
     def _encode_media(self, media_ids: list[int]) -> list[str] | None:
         """Fetch each generated media row by id and encode it as a data URI.

--- a/penny/penny/channels/browser/models.py
+++ b/penny/penny/channels/browser/models.py
@@ -100,6 +100,7 @@ class BrowserConfigUpdate(BaseModel):
     type: str
     key: str
     value: str
+    request_id: str | None = None
 
 
 class BrowserRegister(BaseModel):

--- a/penny/penny/channels/ios/channel.py
+++ b/penny/penny/channels/ios/channel.py
@@ -10,7 +10,7 @@ import logging
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import httpx
@@ -104,6 +104,7 @@ from penny.channels.permission_manager import PermissionManager
 from penny.config_params import RUNTIME_CONFIG_PARAMS, get_params_by_group
 from penny.constants import ChannelType, PennyConstants, PermissionResolution
 from penny.conversation_machine import ConversationMachine, ConversationState
+from penny.database.media_store import ImageSelectionPolicy
 from penny.database.memory import (
     EntryInput,
     MemoryAlreadyExistsError,
@@ -192,6 +193,17 @@ class IosChannel(MessageChannel):
     def sender_id(self) -> str:
         """Identifier for outgoing iOS messages."""
         return "penny"
+
+    def _image_selection_policy(self) -> ImageSelectionPolicy:
+        if self._config is None:
+            return ImageSelectionPolicy()
+        runtime = self._config.runtime
+        return ImageSelectionPolicy(
+            automatic=bool(runtime.IOS_AUTOMATIC_IMAGES),
+            cited_page=bool(runtime.IOS_CITED_PAGE_IMAGES),
+            same_site=bool(runtime.IOS_SAME_SITE_IMAGES),
+            related=bool(runtime.IOS_RELATED_IMAGES),
+        )
 
     def set_permission_manager(self, manager: PermissionManager) -> None:
         """Set the permission manager for routing iOS permission decisions."""
@@ -429,7 +441,9 @@ class IosChannel(MessageChannel):
 
     # --- Shared admin surface ---
 
-    async def _handle_config_request(self, ws: ServerConnection) -> None:
+    async def _handle_config_request(
+        self, ws: ServerConnection, *, request_id: str | None = None, error: str | None = None
+    ) -> None:
         """Return all runtime config params with current values."""
         params = []
         for group, group_params in get_params_by_group():
@@ -447,7 +461,12 @@ class IosChannel(MessageChannel):
                         "group": group,
                     }
                 )
-        await self._send_json(ws, {"type": BROWSER_RESP_TYPE_CONFIG, "params": params})
+        response = {"type": BROWSER_RESP_TYPE_CONFIG, "params": params}
+        if request_id is not None:
+            response["request_id"] = request_id
+        if error is not None:
+            response["error"] = error
+        await self._send_json(ws, response)
 
     async def _handle_config_update(self, ws: ServerConnection, data: dict) -> None:
         """Validate and persist a single config param update."""
@@ -459,17 +478,23 @@ class IosChannel(MessageChannel):
         param = RUNTIME_CONFIG_PARAMS.get(req.key)
         if not param:
             logger.warning("Unknown config key: %s", req.key)
+            await self._handle_config_request(
+                ws,
+                request_id=req.request_id,
+                error="Unknown setting. Refresh settings and try again.",
+            )
             return
         try:
             validated = param.validator(req.value)
         except ValueError as error:
             logger.warning("Invalid config value %s=%s: %s", req.key, req.value, error)
+            await self._handle_config_request(ws, request_id=req.request_id, error=str(error))
             return
         with Session(self._db.engine) as session:
             existing = session.get(RuntimeConfig, req.key)
             if existing:
                 existing.value = str(validated)
-                existing.updated_at = datetime.utcnow()
+                existing.updated_at = datetime.now(UTC)
                 session.add(existing)
             else:
                 session.add(
@@ -477,12 +502,12 @@ class IosChannel(MessageChannel):
                         key=req.key,
                         value=str(validated),
                         description=param.description,
-                        updated_at=datetime.utcnow(),
+                        updated_at=datetime.now(UTC),
                     )
                 )
             session.commit()
         logger.info("Config updated via iOS: %s = %s", req.key, validated)
-        await self._handle_config_request(ws)
+        await self._handle_config_request(ws, request_id=req.request_id)
 
     _PROMPT_LOG_PAGE_SIZE = 50
 

--- a/penny/penny/config_params.py
+++ b/penny/penny/config_params.py
@@ -19,6 +19,7 @@ GROUP_MEMORY = "Memory"
 GROUP_BROWSE = "Browse"
 GROUP_SEND = "Send"
 GROUP_EMAIL = "Email"
+GROUP_IOS_ATTACHMENTS = "iOS Attachments"
 
 # Ordered list for display
 CONFIG_GROUPS: list[str] = [
@@ -28,6 +29,7 @@ CONFIG_GROUPS: list[str] = [
     GROUP_BROWSE,
     GROUP_SEND,
     GROUP_EMAIL,
+    GROUP_IOS_ATTACHMENTS,
 ]
 
 
@@ -71,6 +73,13 @@ def _validate_positive_int(value: str) -> int:
         raise ValueError("must be a positive integer")
 
     return parsed
+
+
+def _validate_switch(value: str) -> int:
+    """Parse a runtime switch without accepting other integer values."""
+    if value not in ("0", "1"):
+        raise ValueError("must be 0 or 1")
+    return int(value)
 
 
 def _validate_non_negative_int(value: str) -> int:
@@ -369,6 +378,22 @@ ConfigParam(
     validator=_validate_positive_float,
     group=GROUP_EMAIL,
 )
+
+
+for _key, _description in (
+    ("IOS_AUTOMATIC_IMAGES", "Attach automatic images to new iOS replies"),
+    ("IOS_CITED_PAGE_IMAGES", "Include automatic images from exact cited pages"),
+    ("IOS_SAME_SITE_IMAGES", "Include automatic images from other pages on cited sites"),
+    ("IOS_RELATED_IMAGES", "Include broader related images, including previously generated images"),
+):
+    ConfigParam(
+        key=_key,
+        description=_description,
+        type=int,
+        default=1,
+        validator=_validate_switch,
+        group=GROUP_IOS_ATTACHMENTS,
+    )
 
 
 class RuntimeParams:

--- a/penny/penny/database/media_store.py
+++ b/penny/penny/database/media_store.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import NamedTuple
 from urllib.parse import urlparse
 
+from pydantic import BaseModel
 from similarity.embeddings import find_similar
 from sqlmodel import Session, select
 
@@ -40,6 +41,23 @@ class _Candidate(NamedTuple):
     source_url: str
     created_at: datetime
     vector: list[float] | None
+
+
+class ImageSelectionPolicy(BaseModel):
+    """Automatic image categories allowed by a delivery channel."""
+
+    automatic: bool = True
+    cited_page: bool = True
+    same_site: bool = True
+    related: bool = True
+
+    def allows(self, row: _Candidate, urls: list[str]) -> bool:
+        """Classify by the strongest relationship so blocked rows cannot fall through."""
+        if _normalize_url(row.source_url) in {_normalize_url(url) for url in urls}:
+            return self.cited_page
+        if _domain(row.source_url) in ({_domain(url) for url in urls} - {""}):
+            return self.same_site
+        return self.related
 
 
 class MediaStore:
@@ -87,7 +105,13 @@ class MediaStore:
         with self._session() as session:
             return session.get(Media, media_id)
 
-    def select_image(self, urls: list[str], embedding: list[float] | None) -> Media | None:
+    def select_image(
+        self,
+        urls: list[str],
+        embedding: list[float] | None,
+        *,
+        policy: ImageSelectionPolicy | None = None,
+    ) -> Media | None:
         """Pick the image to attach to an egress message, most-relevant first.
 
         ``urls`` are the links the message itself contains (Penny cites her
@@ -103,10 +127,13 @@ class MediaStore:
            random pick among the top-K so a centroid "magnet" image can't repeat
            on consecutive messages (jitter applies *only* to this fallback).
 
-        Returns None only when nothing qualifies (no URL match and no embedded
-        media), so a reply still carries an image whenever one can be matched.
+        The optional channel policy excludes disabled categories before matching.
+        Returns None when automatic images are off or no eligible image qualifies.
         """
-        rows = self._candidates()
+        policy = policy or ImageSelectionPolicy()
+        if not policy.automatic:
+            return None
+        rows = [row for row in self._candidates() if policy.allows(row, urls)]
         chosen = (
             self._cited_page_image(rows, urls)
             or self._cited_domain_image(rows, urls, embedding)

--- a/penny/penny/tests/channels/test_ios_channel.py
+++ b/penny/penny/tests/channels/test_ios_channel.py
@@ -1117,3 +1117,114 @@ async def test_sent_message_embedding_reaches_pull_and_history_wire_records(db):
     )
     history_record = ws.sent[-1]["messages"][0]
     assert history_record["embedding"] == "AACAPwAAAD8AAIC/"
+
+
+@pytest.mark.asyncio
+async def test_image_settings_are_validated_shared_and_persisted(db, test_config):
+    from penny.config_params import GROUP_IOS_ATTACHMENTS, RuntimeParams
+
+    channel = _make_channel(db)
+    test_config.runtime = RuntimeParams(db=db)
+    channel._config = test_config
+    response = await _ios_admin_request(channel, {"type": "config_request"})
+    settings = [param for param in response["params"] if param["group"] == GROUP_IOS_ATTACHMENTS]
+    assert len(settings) == 4
+    assert all(param["value"] == param["default"] == "1" for param in settings)
+    for param in settings:
+        request = {
+            "type": "config_update",
+            "key": param["key"],
+            "value": "0",
+            "request_id": "save-1",
+        }
+        saved = await _ios_admin_request(channel, request)
+        assert saved["request_id"] == "save-1"
+        assert "error" not in saved
+        # A fresh accessor (as after restart) and another iOS channel see the same DB override.
+        assert getattr(RuntimeParams(db=db), param["key"]) == 0
+        for invalid in ("2", "-1", "true", "", "0.0"):
+            rejected = await _ios_admin_request(channel, {**request, "value": invalid})
+            assert rejected["request_id"] == "save-1"
+            assert rejected["error"] == "must be 0 or 1"
+            assert getattr(RuntimeParams(db=db), param["key"]) == 0
+    other = _make_channel(db)
+    other._config = test_config
+    response = await _ios_admin_request(other, {"type": "config_request"})
+    assert all(
+        param["value"] == "0"
+        for param in response["params"]
+        if param["group"] == GROUP_IOS_ATTACHMENTS
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("collector", [False, True])
+async def test_ios_image_policy_only_changes_new_automatic_deliveries(db, test_config, collector):
+    import base64
+
+    from penny.config_params import RuntimeParams
+    from penny.scheduler.send_queue_drainer import SendQueueDrainer
+
+    channel = _make_channel(db)
+    test_config.runtime = RuntimeParams(db=db)
+    channel._config = test_config
+    ws = FakeWs()
+    await channel._handle_register(
+        cast(Any, ws),
+        {
+            "type": IOS_MSG_TYPE_REGISTER,
+            "device_id": "ios-keychain-id",
+            "label": "iPhone",
+            "pairing_token": "pair-me",
+        },
+    )
+    device = db.devices.get_by_identifier("ios-keychain-id")
+    assert device is not None and device.id is not None
+    media_id = db.media.put(b"page", "image/png", source_url="https://site.test/p")
+    content = "See https://site.test/p"
+
+    async def deliver():
+        if collector:
+            db.send_queue.enqueue(content=content, collection="test-images")
+            drainer = SendQueueDrainer(db, test_config)
+            drainer.set_channel(channel)
+            db.messages.log_message("incoming", "ios-keychain-id", "run now")
+            assert await drainer.execute()
+        else:
+            await channel.send_response("ios-keychain-id", content, parent_id=None, author="chat")
+
+    await deliver()
+    first = db.ios.pending_for_device(device.id)[0]
+    expected = [f"data:image/png;base64,{base64.b64encode(b'page').decode()}"]
+    assert json.loads(first.attachments_json) == expected
+    await _ios_admin_request(
+        channel, {"type": "config_update", "key": "IOS_AUTOMATIC_IMAGES", "value": "0"}
+    )
+    await deliver()
+    pending = db.ios.pending_for_device(device.id)
+    assert len(pending) == 2
+    assert pending[1].attachments_json is None
+    # Direct attachments and current-run generated IDs bypass the automatic policy.
+    await channel.send_response("ios-keychain-id", "explicit", None, "chat", attachments=expected)
+    await channel.send_response("ios-keychain-id", "generated", None, "chat", media_ids=[media_id])
+    await channel.send_response("ios-keychain-id", content, None, "chat", media_ids=[999999])
+    pending = db.ios.pending_for_device(device.id)
+    assert [json.loads(row.attachments_json) for row in pending[2:4]] == [expected, expected]
+    assert pending[4].attachments_json is None  # missing generated ID obeys fallback policy
+    await channel._handle_pull(cast(Any, ws), {"type": IOS_MSG_TYPE_PULL}, "ios-keychain-id")
+    assert ws.sent[-1]["messages"][0]["attachments"] == expected
+    await channel._handle_history(cast(Any, ws), {"type": IOS_MSG_TYPE_HISTORY}, "ios-keychain-id")
+    history = ws.sent[-1]["messages"]
+    assert (
+        next(row for row in history if row.get("outbox_id") == first.id)["attachments"] == expected
+    )
+    await channel._handle_history(
+        cast(Any, ws),
+        {
+            "type": IOS_MSG_TYPE_HISTORY,
+            "include_attachments": False,
+        },
+        "ios-keychain-id",
+    )
+    assert all(row["attachments"] == [] for row in ws.sent[-1]["messages"])
+    await channel.close()

--- a/penny/penny/tests/database/test_image_selection_policy.py
+++ b/penny/penny/tests/database/test_image_selection_policy.py
@@ -1,0 +1,66 @@
+"""Automatic-image settings partition candidates before the existing ranking ladder."""
+
+from itertools import product
+
+import pytest
+
+from penny.database.media_store import ImageSelectionPolicy
+from penny.llm.embeddings import serialize_embedding
+
+
+@pytest.mark.parametrize(
+    "automatic,cited_page,same_site,related", tuple(product((False, True), repeat=4))
+)
+@pytest.mark.parametrize(
+    "source_url,category",
+    [
+        ("https://www.example.test/article", "cited_page"),
+        ("https://example.test/other", "same_site"),
+        ("https://elsewhere.test/page", "related"),
+        (None, "related"),
+    ],
+)
+def test_each_candidate_keeps_its_strongest_category(
+    db, automatic, cited_page, same_site, related, source_url, category
+):
+    policy = ImageSelectionPolicy(
+        automatic=automatic, cited_page=cited_page, same_site=same_site, related=related
+    )
+    media_id = db.media.put(
+        b"image",
+        "image/png",
+        source_url=source_url,
+        embedding=serialize_embedding([1.0, 0.0]),
+    )
+    match = db.media.select_image(["https://www.example.test/article."], [1.0, 0.0], policy=policy)
+    assert (match is not None) == (automatic and getattr(policy, category))
+    if match:
+        assert match.id == media_id
+
+
+def test_enabled_lower_categories_still_match_and_generated_media_can_be_reused(db):
+    cited = db.media.put(b"cited", "image/png", source_url="https://site.test/p")
+    same = db.media.put(
+        b"same",
+        "image/webp",
+        source_url="https://site.test/other",
+        embedding=serialize_embedding([1.0, 0.0]),
+    )
+    generated = db.media.put(b"drawn", "image/png", embedding=serialize_embedding([1.0, 0.0]))
+    urls = ["https://site.test/p"]
+    match = db.media.select_image(urls, None)
+    assert match is not None and match.id == cited
+    assert db.media.select_image(urls, None, policy=ImageSelectionPolicy(cited_page=False)) is None
+    match = db.media.select_image(urls, [1.0, 0.0], policy=ImageSelectionPolicy(cited_page=False))
+    assert match is not None and match.id == same
+    match = db.media.select_image(
+        urls, [1.0, 0.0], policy=ImageSelectionPolicy(cited_page=False, same_site=False)
+    )
+    assert match is not None and match.id == generated
+    assert (
+        db.media.select_image(urls, [1.0, 0.0], policy=ImageSelectionPolicy(automatic=False))
+        is None
+    )
+    # Default policy remains permissive for channels that do not supply settings.
+    match = db.media.select_image(urls, [1.0, 0.0])
+    assert match is not None and match.id == cited


### PR DESCRIPTION
<img width="739" height="1064" alt="7301F412-9D5F-4084-98F3-BBC12D0ACB90_1_105_c" src="https://github.com/user-attachments/assets/760088bd-1ca0-4529-be21-8995188ce01c" />

Adds controls for enabling/disabling image attachment types